### PR TITLE
Switch to Node.js 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -51,5 +51,5 @@ inputs:
     default: '${{ github.token }}'
     required: false
 runs:
-  using: "node12"
+  using: "node16"
   main: "dist/index.js"


### PR DESCRIPTION
Node.js 12 is being deprecated and it's causing a warning. See: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/